### PR TITLE
silence warnings about smartmatch being experimental/deprecated

### DIFF
--- a/lib/Dizzy/Perl2GLSL.pm
+++ b/lib/Dizzy/Perl2GLSL.pm
@@ -3,6 +3,8 @@ package Dizzy::Perl2GLSL;
 use strict;
 use warnings;
 use 5.010;
+no if $] >= 5.017011, warnings => 'experimental::smartmatch';
+no if $] >= 5.037010, warnings => 'deprecated::smartmatch';
 
 use B;
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to dizzy.
We thought you might be interested in it too.

    Description: silence warnings about smartmatch being experimental/deprecated
     This only saves time until smartmatch is removed in perl 5.42.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2023-08-23
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/dizzy/raw/master/debian/patches/smartmatch.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
